### PR TITLE
ND-568 Renovate Bot disabled  to avoid conflicts

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,3 +1,6 @@
 {
+
+  "_comment": "Further to outcome of ND-568 disabling renovatebot temporarily to avoid conflicts with Dependabot",
+  "enabled": false,
   "$schema": "https://docs.renovatebot.com/renovate-schema.json"
 }

--- a/renovate.json
+++ b/renovate.json
@@ -1,5 +1,4 @@
 {
-
   "_comment": "Further to outcome of ND-568 disabling renovatebot temporarily to avoid conflicts with Dependabot",
   "enabled": false,
   "$schema": "https://docs.renovatebot.com/renovate-schema.json"


### PR DESCRIPTION
Discussed at dev refinement and  team decided to use Dependabot and disable Renovatebot to avoid any conflicts between both.

Following the documentation
https://docs.renovatebot.com/configuration-options/ disabled Renovatebot as part of ND-568