### PR TITLE
ND-630 Removed unsupported argument

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,5 +1,4 @@
 {
-  "_comment": "Further to outcome of ND-568 disabling renovatebot temporarily to avoid conflicts with Dependabot",
   "enabled": false,
   "$schema": "https://docs.renovatebot.com/renovate-schema.json"
 }


### PR DESCRIPTION
Removed _comment argument which is not supported and causing the renovate bot to fail

ND-630