### PR TITLE
ND-271 Dependabot ticket auto-creation in Jira

### DIFF
--- a/.github/workflows/issue-to-jira-trigger.yml
+++ b/.github/workflows/issue-to-jira-trigger.yml
@@ -1,10 +1,9 @@
-name: Add Dependabot Issue to Jira Board On Open/Modified
+name: Add Issue to Jira Board On Close
 
 on:
-  pull_request:
+  issues:
     types:
-      - opened
-      - review_requested
+      - closed
 
 jobs:
   call-workflow-issue-to-jira:

--- a/.github/workflows/issue-to-jira-trigger.yml
+++ b/.github/workflows/issue-to-jira-trigger.yml
@@ -1,9 +1,10 @@
-name: Add Issue to Jira Board On Close
+name: Add Dependabot Issue to Jira Board On Open/Modified
 
 on:
-  issues:
+  pull_request:
     types:
-      - closed
+      - opened
+      - review_requested
 
 jobs:
   call-workflow-issue-to-jira:

--- a/.github/workflows/issue-to-jira.yml
+++ b/.github/workflows/issue-to-jira.yml
@@ -14,21 +14,20 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
-    name: Create Jira Ticket for Dependabot PR
-    if: ${{ github.event.pull_request.user.login  == 'dependabot[bot]' }} # dependabot user
+    name: Create Jira Ticket
     steps:
-    - name: Login to Jira
+    - name: Login
       uses: atlassian/gajira-login@master
       env:
         JIRA_BASE_URL: ${{ secrets.TECH_SERVICES_JIRA_URL }}
         JIRA_USER_EMAIL: ${{ secrets.TECH_SERVICES_JIRA_EMAIL }}
         JIRA_API_TOKEN: ${{ secrets.TECH_SERVICES_JIRA_TOKEN }}
 
-    - name: Create Jira Issue
+    - name: Create
       id: create
       uses: atlassian/gajira-create@master
       with:
-        project: ND
+        project: CNSA
         issuetype: Story
         summary: |
            ${{ github.event.issue.title }} [GH#${{ github.event.issue.number }}]
@@ -37,7 +36,6 @@ jobs:
           *Created By:* ${{ github.event.issue.user.login }}
           [Github permalink|${{ github.event.issue.html_url }}]
           {panel}
-
     - name: Log created issue
       run: echo "Issue ${{ steps.create.outputs.issue }} was created"
 
@@ -49,10 +47,10 @@ jobs:
           issue_number: context.issue.number,
           owner: context.repo.owner,
           repo: context.repo.repo,
-          body: '${{ steps.create.outputs.issue }} created on Jira board and transitioned to Open' })
+          body: '${{ steps.create.outputs.issue }} created on Jira board and transitioned to Done' })
         
     - name: Transition issue
       uses: atlassian/gajira-transition@master
       with:
         issue: ${{ steps.create.outputs.issue }}
-        transition: "Open"
+        transition: "Done"

--- a/.github/workflows/issue-to-jira.yml
+++ b/.github/workflows/issue-to-jira.yml
@@ -14,20 +14,21 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
-    name: Create Jira Ticket
+    name: Create Jira Ticket for Dependabot PR
+    if: ${{ github.event.pull_request.user.login  == 'dependabot[bot]' }} # dependabot user
     steps:
-    - name: Login
+    - name: Login to Jira
       uses: atlassian/gajira-login@master
       env:
         JIRA_BASE_URL: ${{ secrets.TECH_SERVICES_JIRA_URL }}
         JIRA_USER_EMAIL: ${{ secrets.TECH_SERVICES_JIRA_EMAIL }}
         JIRA_API_TOKEN: ${{ secrets.TECH_SERVICES_JIRA_TOKEN }}
 
-    - name: Create
+    - name: Create Jira Issue
       id: create
       uses: atlassian/gajira-create@master
       with:
-        project: CNSA
+        project: ND
         issuetype: Story
         summary: |
            ${{ github.event.issue.title }} [GH#${{ github.event.issue.number }}]
@@ -36,6 +37,7 @@ jobs:
           *Created By:* ${{ github.event.issue.user.login }}
           [Github permalink|${{ github.event.issue.html_url }}]
           {panel}
+
     - name: Log created issue
       run: echo "Issue ${{ steps.create.outputs.issue }} was created"
 
@@ -47,10 +49,10 @@ jobs:
           issue_number: context.issue.number,
           owner: context.repo.owner,
           repo: context.repo.repo,
-          body: '${{ steps.create.outputs.issue }} created on Jira board and transitioned to Done' })
+          body: '${{ steps.create.outputs.issue }} created on Jira board and transitioned to Open' })
         
     - name: Transition issue
       uses: atlassian/gajira-transition@master
       with:
         issue: ${{ steps.create.outputs.issue }}
-        transition: "Done"
+        transition: "Open"

--- a/renovate.json
+++ b/renovate.json
@@ -1,5 +1,4 @@
 {
-  "_comment": "Further to outcome of ND-568 disabling renovatebot temporarily to avoid conflicts with Dependabot",
   "enabled": false,
   "$schema": "https://docs.renovatebot.com/renovate-schema.json"
 }


### PR DESCRIPTION
The dependabot-pr-to-jira.yml workflow automates the process of tracking Dependabot PRs in Jira. 
It ensures that each PR is either matched to an existing Jira ticket or creates a new issue, allowing team to better manage dependency updates. 

The workflow is scheduled to run every Monday at 4 PM UTC.

ND-271
