### PR TITLE
Nd 271 spike dependabot ticket auto creation in jira

### DIFF
--- a/.github/workflows/dependabot-pr-to-jira-trigger.yml
+++ b/.github/workflows/dependabot-pr-to-jira-trigger.yml
@@ -1,14 +1,33 @@
-name: Add Issue to Jira Board On new Dependabot PR's
+#name: Add Issue to Jira Board with details of Dependabot PR's
+#
+#on:
+#  push:
+#    branches:
+#      - ND-271-spike-dependabot-ticket-auto-creation-in-jira
+#
+#jobs:
+#  call-workflow-dependabot-pr-to-jira:
+#    if: github.ref == 'refs/heads/ND-271-spike-dependabot-ticket-auto-creation-in-jira'
+#    uses: ministryofjustice/nvvs-devops-github-actions/.github/workflows/dependabot-pr-to-jira.yml@ND-271-spike-dependabot-ticket-auto-creation-in-jira
+#    secrets:
+#      TECH_SERVICES_JIRA_URL: ${{ secrets.TECH_SERVICES_JIRA_URL }}
+#      TECH_SERVICES_JIRA_EMAIL: ${{ secrets.TECH_SERVICES_JIRA_EMAIL }}
+#      TECH_SERVICES_JIRA_TOKEN: ${{ secrets.TECH_SERVICES_JIRA_TOKEN }}
+
+
+name: Add Issue to Jira Board with details of Dependabot PR's
 
 on:
+  schedule:
+    - cron: '0 16 * * 1' # Runs every Monday at 4 PM UTC
   push:
     branches:
-      - ND-271-spike-dependabot-ticket-auto-creation-in-jira
+      - main
 
 jobs:
   call-workflow-dependabot-pr-to-jira:
-    if: github.ref == 'refs/heads/ND-271-spike-dependabot-ticket-auto-creation-in-jira'
-    uses: ministryofjustice/nvvs-devops-github-actions/.github/workflows/dependabot-pr-to-jira.yml@ND-271-spike-dependabot-ticket-auto-creation-in-jira
+    if: github.ref == 'refs/heads/main'
+    uses: ministryofjustice/nvvs-devops-github-actions/.github/workflows/dependabot-pr-to-jira.yml@main
     secrets:
       TECH_SERVICES_JIRA_URL: ${{ secrets.TECH_SERVICES_JIRA_URL }}
       TECH_SERVICES_JIRA_EMAIL: ${{ secrets.TECH_SERVICES_JIRA_EMAIL }}

--- a/.github/workflows/dependabot-pr-to-jira-trigger.yml
+++ b/.github/workflows/dependabot-pr-to-jira-trigger.yml
@@ -20,9 +20,6 @@ name: Add Issue to Jira Board with details of Dependabot PR's
 on:
   schedule:
     - cron: '0 16 * * 1' # Runs every Monday at 4 PM UTC
-  push:
-    branches:
-      - main
 
 jobs:
   call-workflow-dependabot-pr-to-jira:

--- a/.github/workflows/dependabot-pr-to-jira-trigger.yml
+++ b/.github/workflows/dependabot-pr-to-jira-trigger.yml
@@ -1,20 +1,3 @@
-#name: Add Issue to Jira Board with details of Dependabot PR's
-#
-#on:
-#  push:
-#    branches:
-#      - ND-271-spike-dependabot-ticket-auto-creation-in-jira
-#
-#jobs:
-#  call-workflow-dependabot-pr-to-jira:
-#    if: github.ref == 'refs/heads/ND-271-spike-dependabot-ticket-auto-creation-in-jira'
-#    uses: ministryofjustice/nvvs-devops-github-actions/.github/workflows/dependabot-pr-to-jira.yml@ND-271-spike-dependabot-ticket-auto-creation-in-jira
-#    secrets:
-#      TECH_SERVICES_JIRA_URL: ${{ secrets.TECH_SERVICES_JIRA_URL }}
-#      TECH_SERVICES_JIRA_EMAIL: ${{ secrets.TECH_SERVICES_JIRA_EMAIL }}
-#      TECH_SERVICES_JIRA_TOKEN: ${{ secrets.TECH_SERVICES_JIRA_TOKEN }}
-
-
 name: Add Issue to Jira Board with details of Dependabot PR's
 
 on:

--- a/.github/workflows/dependabot-pr-to-jira.yml
+++ b/.github/workflows/dependabot-pr-to-jira.yml
@@ -99,7 +99,7 @@ jobs:
           update_response=$(curl -s -u $JIRA_USERNAME:$JIRA_API_TOKEN \
              -X PUT \
              -H "Content-Type: application/json" \
-             --data "{\"fields\":{\"description\":\"Updated on $CURRENT_DATE \n $PR_DESCRIPTION\"}}" \
+             --data "{\"fields\":{\"description\":\"Updated on $CURRENT_DATE \n Repository : ${{ github.repository }} \n $PR_DESCRIPTION\"}}" \
              "$JIRA_URL/rest/api/2/issue/${{ env.ISSUE_ID }}")
           echo "Updated issue ${{ env.ISSUE_ID }}"
 

--- a/.github/workflows/dependabot-pr-to-jira.yml
+++ b/.github/workflows/dependabot-pr-to-jira.yml
@@ -61,7 +61,7 @@ jobs:
               create_response=$(curl -s -u $JIRA_USERNAME:$JIRA_API_TOKEN \
                  -X POST \
                  -H "Content-Type: application/json" \
-                 --data "{\"fields\":{\"project\":{\"key\":\"ND\"},\"summary\":\"Updated Dependabot PRs\",\"description\":\"$PR_DESCRIPTION\",\"labels\":[\"JDTEST\"]}}" \
+                 --data "{\"fields\":{\"project\":{\"key\":\"ND\"},\"summary\":\"Dependabot PRs\",\"description\":\"$PR_DESCRIPTION\",\"labels\":[\"JDTEST\"]}}" \
                  "$JIRA_URL/rest/api/2/issue")
               new_issue_id=$(echo "$create_response" | jq -r '.key')
               echo "Created new issue $new_issue_id"
@@ -71,7 +71,7 @@ jobs:
               update_response=$(curl -s -u $JIRA_USERNAME:$JIRA_API_TOKEN \
                  -X PUT \
                  -H "Content-Type: application/json" \
-                 --data "{\"fields\":{\"description\":\"$PR_DESCRIPTION\"}}" \
+                 --data "{\"fields\":{\"description\":\"Updated $PR_DESCRIPTION\"}}" \
                  "$JIRA_URL/rest/api/2/issue/$issue_id")
               echo "Updated issue $issue_id"
               echo "ISSUE_ID=$issue_id" >> $GITHUB_ENV

--- a/.github/workflows/dependabot-pr-to-jira.yml
+++ b/.github/workflows/dependabot-pr-to-jira.yml
@@ -37,7 +37,7 @@ jobs:
         id: format-prs
         run: |
           # Format PR details into a description suitable for a Jira issue
-          PR_DESCRIPTION=$(jq -r '.[] | "- PR Number: \(.number)  \nTitle: \(.title)  \nBranch: \(.headRefName) \nURL: https://github.com/${{ github.repository }}/pull/\(.number)\n"' pr_list.json | se[...]
+          PR_DESCRIPTION=$(jq -r '.[] | "- PR Number: \(.number)  \nTitle: \(.title)  \nBranch: \(.headRefName) \nURL: https://github.com/${{ github.repository }}/pull/\(.number)\n"' pr_list.json | sed 's/$/\\n/')
           echo "PR_DESCRIPTION=$PR_DESCRIPTION" >> $GITHUB_ENV
 
       # Step: Find Jira tickets in project ND labeled 'Dependabot'

--- a/.github/workflows/dependabot-pr-to-jira.yml
+++ b/.github/workflows/dependabot-pr-to-jira.yml
@@ -71,7 +71,7 @@ jobs:
               update_response=$(curl -s -u $JIRA_USERNAME:$JIRA_API_TOKEN \
                  -X PUT \
                  -H "Content-Type: application/json" \
-                 --data "{\"fields\":{\"description\":\"Updated $PR_DESCRIPTION\"}}" \
+                 --data "{\"fields\":{\"description\":\"Updated\n $PR_DESCRIPTION\"}}" \
                  "$JIRA_URL/rest/api/2/issue/$issue_id")
               echo "Updated issue $issue_id"
               echo "ISSUE_ID=$issue_id" >> $GITHUB_ENV

--- a/.github/workflows/dependabot-pr-to-jira.yml
+++ b/.github/workflows/dependabot-pr-to-jira.yml
@@ -61,8 +61,7 @@ jobs:
           if echo "$response" | jq -e . >/dev/null 2>&1; then
             # Extract the first issue key from the response
              issue_id=$(echo "$response" | jq -r '.issues[0].key // "null"')
-            echo " issue_id from response $issue_id"
-          
+            
             if [ "$issue_count" -eq 0 ]; then
               echo "No issues found with the 'Dependabot' label in project 'ND'. Creating a new issue..."
               create_response=$(curl -s -u $JIRA_USERNAME:$JIRA_API_TOKEN \
@@ -70,6 +69,9 @@ jobs:
                  -H "Content-Type: application/json" \
                  --data "{\"fields\":{\"project\":{\"key\":\"ND\"},\"summary\":\"Dependabot PRs\",\"description\":\"$PR_DESCRIPTION\",\"labels\":[\"Dependabot\"]}}" \
                  "$JIRA_URL/rest/api/2/issue")
+            
+              echo "$create_response" 
+              
               new_issue_id=$(echo "$create_response" | jq -r '.key')
               echo "Created new issue $new_issue_id"
               echo "ISSUE_ID=$new_issue_id" >> $GITHUB_ENV

--- a/.github/workflows/dependabot-pr-to-jira.yml
+++ b/.github/workflows/dependabot-pr-to-jira.yml
@@ -56,9 +56,6 @@ jobs:
           issue_count=$(echo "$response" | jq '.issues | length')
           echo "Number of issues found: $issue_count"
           
-          echo "Jira response: $response"
-          
-          
           # Check if the response is valid JSON
 
           if echo "$response" | jq -e . >/dev/null 2>&1; then
@@ -66,7 +63,7 @@ jobs:
              issue_id=$(echo "$response" | jq -r '.issues[0].key // "null"')
             echo " issue_id from response $issue_id"
           
-            if [ -z "$issue_id" ]; then
+            if [ "$issue_count" -eq 0 ]; then
               echo "No issues found with the 'Dependabot' label in project 'ND'. Creating a new issue..."
               create_response=$(curl -s -u $JIRA_USERNAME:$JIRA_API_TOKEN \
                  -X POST \

--- a/.github/workflows/dependabot-pr-to-jira.yml
+++ b/.github/workflows/dependabot-pr-to-jira.yml
@@ -50,7 +50,7 @@ jobs:
           echo "Searching for issues with the 'jira_dependabot' label in project 'ND'..."
           
           # Define JQL query to find issues with the 'dependabot' label in the 'ND' project
-          JQL_QUERY='labels = jira_dependabot'
+          JQL_QUERY='project = ND AND labels in (JDTEST)'
           
           # Make API request to Jira to search for issues with the given label in the 'ND' project
           response=$(curl -s -u $JIRA_USERNAME:$JIRA_API_TOKEN \

--- a/.github/workflows/dependabot-pr-to-jira.yml
+++ b/.github/workflows/dependabot-pr-to-jira.yml
@@ -61,7 +61,7 @@ jobs:
               create_response=$(curl -s -u $JIRA_USERNAME:$JIRA_API_TOKEN \
                  -X POST \
                  -H "Content-Type: application/json" \
-                 --data "{\"fields\":{\"project\":{\"key\":\"ND\"},\"summary\":\"Dependabot PRs\",\"description\":\"Updated $PR_DESCRIPTION\",\"labels\":[\"JDTEST\"]}}" \
+                 --data "{\"fields\":{\"project\":{\"key\":\"ND\"},\"summary\":\"Updated Dependabot PRs\",\"description\":\"$PR_DESCRIPTION\",\"labels\":[\"JDTEST\"]}}" \
                  "$JIRA_URL/rest/api/2/issue")
               new_issue_id=$(echo "$create_response" | jq -r '.key')
               echo "Created new issue $new_issue_id"

--- a/.github/workflows/dependabot-pr-to-jira.yml
+++ b/.github/workflows/dependabot-pr-to-jira.yml
@@ -67,7 +67,7 @@ jobs:
               create_response=$(curl -s -u $JIRA_USERNAME:$JIRA_API_TOKEN \
                  -X POST \
                  -H "Content-Type: application/json" \
-                 --data "{\"fields\":{\"project\":{\"key\":\"ND\"},\"summary\":\"Dependabot PRs\",\"description\":\"$PR_DESCRIPTION\",\"issuetype\":{\"name\"}:\"Story\",\"labels\":[\"Dependabot\"]}}" \
+                 --data "{\"fields\":{\"project\":{\"key\":\"ND\"},\"summary\":\"Dependabot PRs\",\"description\":\"$PR_DESCRIPTION\",\"issuetype\":{\"name\":\"Story\"},\"labels\":[\"Dependabot\"]}}" \
                  "$JIRA_URL/rest/api/2/issue")
             
               echo "$create_response" 

--- a/.github/workflows/dependabot-pr-to-jira.yml
+++ b/.github/workflows/dependabot-pr-to-jira.yml
@@ -54,9 +54,13 @@ jobs:
             -X GET \
             -H "Content-Type: application/json" \
             "$JIRA_URL/rest/api/2/search?jql=project=ND%20AND%20labels%3D%27Dependabot%27")
+          
           echo "$response" > jira_search_response.json
+          
           issue_count=$(echo "$response" | jq '.issues | length')
           echo "Number of issues found: $issue_count"
+          echo "ISSUE_COUNT=$issue_count" >> $GITHUB_ENV
+          
           if echo "$response" | jq -e . >/dev/null 2>&1; then
             issue_id=$(echo "$response" | jq -r '.issues[0].key // "null"')
             echo "ISSUE_ID=$issue_id" >> $GITHUB_ENV
@@ -67,7 +71,7 @@ jobs:
 
       # Step: Create Jira ticket if none found
       - name: Create Jira ticket
-        if: env.ISSUE_ID == 'null'
+        if: (env.ISSUE_COUNT == 0)
         id: create-jira-ticket
         env:
           JIRA_URL: ${{ secrets.TECH_SERVICES_JIRA_URL }}
@@ -78,7 +82,7 @@ jobs:
           create_response=$(curl -s -u $JIRA_USERNAME:$JIRA_API_TOKEN \
              -X POST \
              -H "Content-Type: application/json" \
-             --data "{\"fields\":{\"project\":{\"key\":\"ND\"},\"summary\":\"Dependabot PRs for ${{ github.repository }}\",\"description\":\"Repository : ${{ github.repository }} \n $PR_DESCRIPTION\",\"issuetype\":{\"name\":\"Story\"},\"labels\":[\"Dependabot\",\"${{ github.repository }}\"]}}" \
+             --data "{\"fields\":{\"project\":{\"key\":\"ND\"},\"summary\":\"Dependabot PRs for ${{ github.repository }}\",\"description\":\"Repository : ${{ github.repository }} \n $PR_DESCRIPTION\",\"issuetype\":{\"name\":\"Story\"},\"labels\":[\"Dependabot\",\"$(echo ${{ github.repository }} | cut -d'/' -f2)\"]}}" \
              "$JIRA_URL/rest/api/2/issue")
           echo "$create_response" 
           new_issue_id=$(echo "$create_response" | jq -r '.key')
@@ -87,7 +91,7 @@ jobs:
 
       # Step: Update Jira ticket if found
       - name: Update Jira ticket
-        if: env.ISSUE_ID != 'null'
+        if: (env.ISSUE_COUNT > 0)
         id: update-jira-ticket
         env:
           JIRA_URL: ${{ secrets.TECH_SERVICES_JIRA_URL }}

--- a/.github/workflows/dependabot-pr-to-jira.yml
+++ b/.github/workflows/dependabot-pr-to-jira.yml
@@ -37,7 +37,7 @@ jobs:
         id: format-prs
         run: |
           # Format PR details into a description suitable for a Jira issue
-          PR_DESCRIPTION=$(jq -r '.[] | "- PR Number: \(.number)  \nTitle: \(.title)  \nBranch: \(.headRefName) \nURL: https://github.com/${{ github.repository }}/pull/\(.number)\n"' pr_list.json | sed 's/$/\\n/')
+          PR_DESCRIPTION=$(jq -r '.[] | "- PR Number: \(.number)  \nTitle: \(.title)  \nBranch: \(.headRefName) \nURL: https://github.com/${{ github.repository }}/pull/\(.number)\n"' pr_list.json | sed ':a;N;$!ba;s/\n/\\n/g')
           echo "PR_DESCRIPTION=$PR_DESCRIPTION" >> $GITHUB_ENV
 
       # Step: Find Jira tickets in project ND labeled 'Dependabot'

--- a/.github/workflows/dependabot-pr-to-jira.yml
+++ b/.github/workflows/dependabot-pr-to-jira.yml
@@ -16,6 +16,12 @@ jobs:
     runs-on: ubuntu-latest
     name: Create or Update Jira Ticket
     steps:
+
+      # Step: Set repo name
+      - name: Set repository name
+        id: set-repo-name
+        run: echo "REPO_NAME=$(echo ${{ github.repository }} | cut -d'/' -f2)" >> $GITHUB_ENV
+
       # Step: List open Dependabot PRs on the main branch
       - name: List open Dependabot PRs on main branch
         id: list-prs
@@ -82,7 +88,7 @@ jobs:
           create_response=$(curl -s -u $JIRA_USERNAME:$JIRA_API_TOKEN \
              -X POST \
              -H "Content-Type: application/json" \
-             --data "{\"fields\":{\"project\":{\"key\":\"ND\"},\"summary\":\"Dependabot PRs for ${{ github.repository }}\",\"description\":\"Repository : ${{ github.repository }} \n $PR_DESCRIPTION\",\"issuetype\":{\"name\":\"Story\"},\"labels\":[\"Dependabot\",\"$(echo ${{ github.repository }} | cut -d'/' -f2)\"]}}" \
+             --data "{\"fields\":{\"project\":{\"key\":\"ND\"},\"summary\":\"Dependabot PRs for ${{ env.REPO_NAME }}\",\"description\":\"Repository : ${{ env.REPO_NAME}} \n $PR_DESCRIPTION\",\"issuetype\":{\"name\":\"Story\"},\"labels\":[\"Dependabot\",\"${{ env.REPO_NAME }}"\]}}" \
              "$JIRA_URL/rest/api/2/issue")
           echo "$create_response" 
           new_issue_id=$(echo "$create_response" | jq -r '.key')
@@ -103,7 +109,7 @@ jobs:
           update_response=$(curl -s -u $JIRA_USERNAME:$JIRA_API_TOKEN \
              -X PUT \
              -H "Content-Type: application/json" \
-             --data "{\"fields\":{\"description\":\"Updated on $CURRENT_DATE \n Repository : ${{ github.repository }} \n $PR_DESCRIPTION\"}}" \
+             --data "{\"fields\":{\"description\":\"Updated on $CURRENT_DATE \n Repository : ${{ env.REPO_NAME }} \n $PR_DESCRIPTION\"}}" \
              "$JIRA_URL/rest/api/2/issue/${{ env.ISSUE_ID }}")
           echo "Updated issue ${{ env.ISSUE_ID }}"
 

--- a/.github/workflows/dependabot-pr-to-jira.yml
+++ b/.github/workflows/dependabot-pr-to-jira.yml
@@ -50,13 +50,12 @@ jobs:
           echo "Searching for issues with the 'jira_dependabot' label in project 'ND'..."
           
           # Define JQL query to find issues with the 'dependabot' label in the 'ND' project
-          JQL_QUERY='project="ND" AND labels="jira_dependabot"'
+          JQL_QUERY='project = ND AND labels = jira_dependabot AND fields=id,key'
           
           # Make API request to Jira to search for issues with the given label in the 'ND' project
           response=$(curl -s -u $JIRA_USERNAME:$JIRA_API_TOKEN \
-            -X POST \
+            -X GET \
             -H "Content-Type: application/json" \
-            --data "{\"jql\":\"$JQL_QUERY\",\"fields\":[\"id\",\"key\"]}" \
             "$JIRA_URL/rest/api/2/search")
           
           # Write the response to an environment variable

--- a/.github/workflows/dependabot-pr-to-jira.yml
+++ b/.github/workflows/dependabot-pr-to-jira.yml
@@ -124,7 +124,7 @@ jobs:
         uses: actions/github-script@v7
         with:
           script: |
-            # Read the list of PRs from the generated JSON file
+          # Read the list of PRs from the generated JSON file
             const fs = require('fs');
             const prs = JSON.parse(fs.readFileSync('pr_list.json', 'utf8'));
             

--- a/.github/workflows/dependabot-pr-to-jira.yml
+++ b/.github/workflows/dependabot-pr-to-jira.yml
@@ -41,16 +41,16 @@ jobs:
           JIRA_USERNAME: ${{ secrets.TECH_SERVICES_JIRA_EMAIL }}
         run: |
           CURRENT_DATE=$(date '+%Y-%m-%d %H:%M:%S')
-          echo "Searching for issues with the 'JDTEST' label in project 'ND'..."
+          echo "Searching for issues with the 'Dependabot' label in project 'ND'..."
           
           # Define JQL query to find issues with the 'dependabot' label in the 'ND' project
-          JQL_QUERY='project = ND AND labels in (JDTEST)'
+          JQL_QUERY='project = ND AND labels in (Dependabot)'
           
           # Make API request to Jira to search for issues with the given label in the 'ND' project
           response=$(curl -s -u $JIRA_USERNAME:$JIRA_API_TOKEN \
             -X GET \
             -H "Content-Type: application/json" \
-            "$JIRA_URL/rest/api/2/search?jql=project=ND%20AND%20labels%3D%27JDTEST%27")
+            "$JIRA_URL/rest/api/2/search?jql=project=ND%20AND%20labels%3D%27Dependabot%27")
           
           # Check if the response is valid JSON
           if echo "$response" | jq -e . >/dev/null 2>&1; then
@@ -58,11 +58,11 @@ jobs:
             issue_id=$(echo "$response" | jq -r '.issues[0].key')
           
             if [ -z "$issue_id" ]; then
-              echo "No issues found with the 'JDTEST' label in project 'ND'. Creating a new issue..."
+              echo "No issues found with the 'Dependabot' label in project 'ND'. Creating a new issue..."
               create_response=$(curl -s -u $JIRA_USERNAME:$JIRA_API_TOKEN \
                  -X POST \
                  -H "Content-Type: application/json" \
-                 --data "{\"fields\":{\"project\":{\"key\":\"ND\"},\"summary\":\"Dependabot PRs\",\"description\":\"$PR_DESCRIPTION\",\"labels\":[\"JDTEST\"]}}" \
+                 --data "{\"fields\":{\"project\":{\"key\":\"ND\"},\"summary\":\"Dependabot PRs\",\"description\":\"$PR_DESCRIPTION\",\"labels\":[\"Dependabot\"]}}" \
                  "$JIRA_URL/rest/api/2/issue")
               new_issue_id=$(echo "$create_response" | jq -r '.key')
               echo "Created new issue $new_issue_id"

--- a/.github/workflows/dependabot-pr-to-jira.yml
+++ b/.github/workflows/dependabot-pr-to-jira.yml
@@ -56,7 +56,7 @@ jobs:
           response=$(curl -s -u $JIRA_USERNAME:$JIRA_API_TOKEN \
             -X GET \
             -H "Content-Type: application/json" \
-            "$JIRA_URL/rest/api/2/search/$JQL_QUERY")
+            "$JIRA_URL/rest/api/2/search?jql=$JQL_QUERY")
           
           # Write the response to an environment variable
           echo "JIRA_RESPONSE=$response" >> $GITHUB_ENV

--- a/.github/workflows/dependabot-pr-to-jira.yml
+++ b/.github/workflows/dependabot-pr-to-jira.yml
@@ -16,13 +16,13 @@ jobs:
     runs-on: ubuntu-latest
     name: Create or Update Jira Ticket
     steps:
-      # Step 1: List open Dependabot PRs on the main branch
+      # Step: List open Dependabot PRs on the main branch
       - name: List open Dependabot PRs on main branch
         id: list-prs
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
-          # Get a list of open PRs with the 'dependabot' label, and save them to a JSON file
+          # Get a list of open PRs created by  'dependabot' and save them to a JSON file
           gh pr list --repo ${{ github.repository }} --base main --json number,title,headRefName -A app/dependabot --search "status:success review:none" > pr_list.json
           
           # Check if the output is valid JSON
@@ -32,15 +32,15 @@ jobs:
             exit 1
           fi
 
-      # Step 2: Format the PRs for Jira ticket description
+      # Step: Format the PRs for Jira ticket description
       - name: Format PRs for Jira ticket Description
         id: format-prs
         run: |
           # Format PR details into a description suitable for a Jira issue
-          PR_DESCRIPTION=$(jq -r '.[] | "- PR Number: \(.number)  \nTitle: \(.title)  \nBranch: \(.headRefName) \nURL: https://github.com/${{ github.repository }}/pull/\(.number)\n"' pr_list.json | sed ':a;N;$!ba;s/\n/\\n/g')
+          PR_DESCRIPTION=$(jq -r '.[] | "- PR Number: \(.number)  \nTitle: \(.title)  \nBranch: \(.headRefName) \nURL: https://github.com/${{ github.repository }}/pull/\(.number)\n"' pr_list.json | se[...]
           echo "PR_DESCRIPTION=$PR_DESCRIPTION" >> $GITHUB_ENV
 
-      # Step 3: Find Jira tickets in project ND labeled 'Dependabot'
+      # Step: Find Jira tickets in project ND labeled 'Dependabot'
       - name: Find Jira tickets in project ND labeled Dependabot
         id: find-jira-ticket
         env:
@@ -48,69 +48,65 @@ jobs:
           JIRA_API_TOKEN: ${{ secrets.TECH_SERVICES_JIRA_TOKEN }}
           JIRA_USERNAME: ${{ secrets.TECH_SERVICES_JIRA_EMAIL }}
         run: |
-          CURRENT_DATE=$(date '+%Y-%m-%d %H:%M:%S')
           echo "Searching for issues with the 'Dependabot' label in project 'ND'..."
-          
-          # Define JQL query to find issues with the 'Dependabot' label in the 'ND' project
           JQL_QUERY='project = ND AND labels in (Dependabot)'
-          
-          # Make API request to Jira to search for issues with the given label in the 'ND' project
           response=$(curl -s -u $JIRA_USERNAME:$JIRA_API_TOKEN \
             -X GET \
             -H "Content-Type: application/json" \
-            "$JIRA_URL/rest/api/2/search?jql=project=ND%20AND%20labels%3D%27Dependabot%27")
-          
-          # Count the number of issues returned by Jira
+            "$JIRA_URL/rest/api/2/search?jql=$JQL_QUERY")
+          echo "$response" > jira_search_response.json
           issue_count=$(echo "$response" | jq '.issues | length')
           echo "Number of issues found: $issue_count"
-          
-          # Check if the response is valid JSON
           if echo "$response" | jq -e . >/dev/null 2>&1; then
-            # Extract the issue key (ID) of the first issue from the response
             issue_id=$(echo "$response" | jq -r '.issues[0].key // "null"')
-          
-            # If no issues are found, create a new issue
-            if [ "$issue_count" -eq 0 ]; then
-              echo "No issues found with the 'Dependabot' label in project 'ND'. Creating a new issue..."
-          
-              # Create a new Jira issue with the formatted PR description
-              create_response=$(curl -s -u $JIRA_USERNAME:$JIRA_API_TOKEN \
-                 -X POST \
-                 -H "Content-Type: application/json" \
-                 --data "{\"fields\":{\"project\":{\"key\":\"ND\"},\"summary\":\"Dependabot PRs\",\"description\":\"$PR_DESCRIPTION\",\"issuetype\":{\"name\":\"Story\"},\"labels\":[\"Dependabot\"]}}" \
-                 "$JIRA_URL/rest/api/2/issue")
-          
-              # Output the full response for logging
-              echo "$create_response" 
-          
-              # Extract the issue ID of the newly created issue
-              new_issue_id=$(echo "$create_response" | jq -r '.key')
-              echo "Created new issue $new_issue_id"
-              echo "ISSUE_ID=$new_issue_id" >> $GITHUB_ENV
-            else
-              # If an issue exists, update the description
-              echo "Found issue $issue_id. Updating the description..."
-          
-              # Update the existing issue's description with new PR details
-              update_response=$(curl -s -u $JIRA_USERNAME:$JIRA_API_TOKEN \
-                 -X PUT \
-                 -H "Content-Type: application/json" \
-                 --data "{\"fields\":{\"description\":\"Updated on $CURRENT_DATE \n $PR_DESCRIPTION\"}}" \
-                 "$JIRA_URL/rest/api/2/issue/$issue_id")
-              echo "Updated issue $issue_id"
-              echo "ISSUE_ID=$issue_id" >> $GITHUB_ENV
-            fi
+            echo "ISSUE_ID=$issue_id" >> $GITHUB_ENV
           else
-            # If the response is invalid JSON, exit with an error
             echo "Invalid JSON response"
             exit 1
           fi
 
-      # Step 4: Log the issue created or updated
+      # Step: Create Jira ticket if none found
+      - name: Create Jira ticket
+        if: env.ISSUE_ID == 'null'
+        id: create-jira-ticket
+        env:
+          JIRA_URL: ${{ secrets.TECH_SERVICES_JIRA_URL }}
+          JIRA_API_TOKEN: ${{ secrets.TECH_SERVICES_JIRA_TOKEN }}
+          JIRA_USERNAME: ${{ secrets.TECH_SERVICES_JIRA_EMAIL }}
+        run: |
+          echo "No issues found with the 'Dependabot' label in project 'ND'. Creating a new issue..."
+          create_response=$(curl -s -u $JIRA_USERNAME:$JIRA_API_TOKEN \
+             -X POST \
+             -H "Content-Type: application/json" \
+             --data "{\"fields\":{\"project\":{\"key\":\"ND\"},\"summary\":\"Dependabot PRs\",\"description\":\"$PR_DESCRIPTION\",\"issuetype\":{\"name\":\"Story\"},\"labels\":[\"Dependabot\"]}}" \
+             "$JIRA_URL/rest/api/2/issue")
+          echo "$create_response" 
+          new_issue_id=$(echo "$create_response" | jq -r '.key')
+          echo "Created new issue $new_issue_id"
+          echo "ISSUE_ID=$new_issue_id" >> $GITHUB_ENV
+
+      # Step: Update Jira ticket if found
+      - name: Update Jira ticket
+        if: env.ISSUE_ID != 'null'
+        id: update-jira-ticket
+        env:
+          JIRA_URL: ${{ secrets.TECH_SERVICES_JIRA_URL }}
+          JIRA_API_TOKEN: ${{ secrets.TECH_SERVICES_JIRA_TOKEN }}
+          JIRA_USERNAME: ${{ secrets.TECH_SERVICES_JIRA_EMAIL }}
+        run: |
+          CURRENT_DATE=$(date '+%Y-%m-%d %H:%M:%S')
+          echo "Found issue ${{ env.ISSUE_ID }}. Updating the description..."
+          update_response=$(curl -s -u $JIRA_USERNAME:$JIRA_API_TOKEN \
+             -X PUT \
+             -H "Content-Type: application/json" \
+             --data "{\"fields\":{\"description\":\"Updated on $CURRENT_DATE \n $PR_DESCRIPTION\"}}" \
+             "$JIRA_URL/rest/api/2/issue/${{ env.ISSUE_ID }}")
+          echo "Updated issue ${{ env.ISSUE_ID }}"
+
+      # Step: Log the issue created or updated
       - name: Log created or updated issue
         id: log-issue-update
         run: |
-          # Check if the ISSUE_ID environment variable is set
           if [ -n "${{ env.ISSUE_ID }}" ]; then
             echo "Issue ${{ env.ISSUE_ID }} was created or updated"
           else
@@ -118,7 +114,7 @@ jobs:
             exit 1
           fi
 
-      # Step 5: Comment on all related PRs on GitHub
+      # Step: Comment on all related PRs on GitHub
       - name: Comment on GitHub
         id: comment-prs
         uses: actions/github-script@v7
@@ -136,7 +132,7 @@ jobs:
               });
             });
 
-      # Step 6: Find transition ID for 'Backlog' in Jira
+      # Step: Find transition ID for 'Backlog' in Jira
       - name: Find transition ID for Backlog
         id: transition-issue
         env:
@@ -144,20 +140,13 @@ jobs:
           JIRA_API_TOKEN: ${{ secrets.TECH_SERVICES_JIRA_TOKEN }}
           JIRA_USERNAME: ${{ secrets.TECH_SERVICES_JIRA_EMAIL }}
         run: |
-          # Get the available transitions for the Jira issue
           transition_response=$(curl -s -u $JIRA_USERNAME:$JIRA_API_TOKEN \
             -X GET \
             -H "Content-Type: application/json" \
             "$JIRA_URL/rest/api/2/issue/${{ env.ISSUE_ID }}/transitions")
-          
-          # Find the transition ID for 'Backlog'
           transition_id=$(echo "$transition_response" | jq -r '.transitions[] | select(.name=="Backlog") | .id')
-          
-          # If the transition ID is not found, exit with an error
           if [ -z "$transition_id" ]; then
             echo "Failed to find transition ID for 'Backlog'"
             exit 1
           fi
-          
-          # Output the transition ID for logging
           echo "TRANSITION_ID=$transition_id" >> $GITHUB_ENV

--- a/.github/workflows/dependabot-pr-to-jira.yml
+++ b/.github/workflows/dependabot-pr-to-jira.yml
@@ -124,11 +124,9 @@ jobs:
         uses: actions/github-script@v7
         with:
           script: |
-          # Read the list of PRs from the generated JSON file
             const fs = require('fs');
             const prs = JSON.parse(fs.readFileSync('pr_list.json', 'utf8'));
             
-            # Loop through all PRs and add a comment indicating the Jira issue update
             prs.forEach(pr => {
               github.rest.issues.createComment({
                 issue_number: pr.number,

--- a/.github/workflows/dependabot-pr-to-jira.yml
+++ b/.github/workflows/dependabot-pr-to-jira.yml
@@ -56,7 +56,7 @@ jobs:
           response=$(curl -s -u $JIRA_USERNAME:$JIRA_API_TOKEN \
             -X GET \
             -H "Content-Type: application/json" \
-            "$JIRA_URL/rest/api/2/search")
+            "$JIRA_URL/rest/api/2/search/$JQL_QUERY")
           
           # Write the response to an environment variable
           echo "JIRA_RESPONSE=$response" >> $GITHUB_ENV

--- a/.github/workflows/dependabot-pr-to-jira.yml
+++ b/.github/workflows/dependabot-pr-to-jira.yml
@@ -51,10 +51,8 @@ jobs:
           
           # Define JQL query to find issues with the 'dependabot' label in the 'ND' project
           JQL_QUERY='project="ND" AND labels="jira_dependabot"'
-          
-          QUERY = "$JIRA_URL/rest/api/2/search?jql=$JQL_QUERY"
-          
-          echo "QUERY=$QUERY" >> $GITHUB_ENV
+           
+          echo "$JIRA_URL/rest/api/2/search?jql=$JQL_QUERY"
           
           # Make API request to Jira to search for issues with the given label in the 'ND' project
           response=$(curl -s -u $JIRA_USERNAME:$JIRA_API_TOKEN \

--- a/.github/workflows/dependabot-pr-to-jira.yml
+++ b/.github/workflows/dependabot-pr-to-jira.yml
@@ -50,7 +50,7 @@ jobs:
           echo "Searching for issues with the 'jira_dependabot' label in project 'ND'..."
           
           # Define JQL query to find issues with the 'dependabot' label in the 'ND' project
-          JQL_QUERY='project = ND AND labels = jira_dependabot AND fields=id,key'
+          JQL_QUERY='project = ND AND labels = jira_dependabot'
           
           # Make API request to Jira to search for issues with the given label in the 'ND' project
           response=$(curl -s -u $JIRA_USERNAME:$JIRA_API_TOKEN \

--- a/.github/workflows/dependabot-pr-to-jira.yml
+++ b/.github/workflows/dependabot-pr-to-jira.yml
@@ -56,6 +56,7 @@ jobs:
           if echo "$response" | jq -e . >/dev/null 2>&1; then
             # Extract the first issue key from the response
             issue_id=$(echo "$response" | jq -r '.issues[0].key')
+            echo " issue_id from response $issue_id"
           
             if [ -z "$issue_id" ]; then
               echo "No issues found with the 'Dependabot' label in project 'ND'. Creating a new issue..."

--- a/.github/workflows/dependabot-pr-to-jira.yml
+++ b/.github/workflows/dependabot-pr-to-jira.yml
@@ -29,7 +29,7 @@ jobs:
           GH_TOKEN: ${{ github.token }}
         run: |
           # Get a list of open PRs created by 'app/dependabot' or 'dependabot[bot]' and save them to a JSON file
-          gh pr list --repo ${{ github.repository }} --base main --json number,title,headRefName --search "author:app/dependabot author:dependabot[bot] status:success review:none" > pr_list.json
+          gh pr list --repo ${{ github.repository }} --base main --json number,title,headRefName --search "author:app/dependabot author:dependabot[bot]" > pr_list.json
   
           # Check if the output is valid JSON
           if ! jq -e . pr_list.json > /dev/null 2>&1; then

--- a/.github/workflows/dependabot-pr-to-jira.yml
+++ b/.github/workflows/dependabot-pr-to-jira.yml
@@ -40,6 +40,7 @@ jobs:
           JIRA_API_TOKEN: ${{ secrets.TECH_SERVICES_JIRA_TOKEN }}
           JIRA_USERNAME: ${{ secrets.TECH_SERVICES_JIRA_EMAIL }}
         run: |
+          CURRENT_DATE=$(date '+%Y-%m-%d %H:%M:%S')
           echo "Searching for issues with the 'JDTEST' label in project 'ND'..."
           
           # Define JQL query to find issues with the 'dependabot' label in the 'ND' project

--- a/.github/workflows/dependabot-pr-to-jira.yml
+++ b/.github/workflows/dependabot-pr-to-jira.yml
@@ -53,6 +53,12 @@ jobs:
             -H "Content-Type: application/json" \
             "$JIRA_URL/rest/api/2/search?jql=project=ND%20AND%20labels%3D%27Dependabot%27")
           
+          issue_count=$(echo "$response" | jq '.issues | length')
+          echo "Number of issues found: $issue_count"
+          
+          echo "Jira response: $response"
+          
+          
           # Check if the response is valid JSON
 
           if echo "$response" | jq -e . >/dev/null 2>&1; then

--- a/.github/workflows/dependabot-pr-to-jira.yml
+++ b/.github/workflows/dependabot-pr-to-jira.yml
@@ -21,7 +21,7 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
-          gh pr list --repo ${{ github.repository }} --base main --json number,title,headRefName,author > pr_list.json
+          gh pr list --repo ${{ github.repository }} --base main --json number,title,headRefName,author --author dependabot > pr_list.json
           if ! jq -e . pr_list.json > /dev/null 2>&1; then
             echo "Invalid JSON output from gh pr list"
             cat pr_list.json

--- a/.github/workflows/dependabot-pr-to-jira.yml
+++ b/.github/workflows/dependabot-pr-to-jira.yml
@@ -28,10 +28,10 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
-          # Get a list of open PRs created by  'dependabot' and save them to a JSON file
-          gh pr list --repo ${{ github.repository }} --base main --json number,title,headRefName -A app/dependabot --search "status:success review:none" > pr_list.json
-          
-          # Check if the output is valid JSON
+        # Get a list of open PRs created by 'app/dependabot' or 'dependabot[bot]' and save them to a JSON file
+          gh pr list --repo ${{ github.repository }} --base main --json number,title,headRefName --search "author:app/dependabot author:dependabot[bot] status:success review:none" > pr_list.json
+  
+        # Check if the output is valid JSON
           if ! jq -e . pr_list.json > /dev/null 2>&1; then
             echo "Invalid JSON output from gh pr list"
             cat pr_list.json

--- a/.github/workflows/dependabot-pr-to-jira.yml
+++ b/.github/workflows/dependabot-pr-to-jira.yml
@@ -51,16 +51,16 @@ jobs:
           
           # Define JQL query to find issues with the 'dependabot' label in the 'ND' project
           JQL_QUERY='project="ND" AND labels="jira_dependabot"'
-           
-          echo "$JIRA_URL/rest/api/2/search?jql=$JQL_QUERY"
           
           # Make API request to Jira to search for issues with the given label in the 'ND' project
-          response=$(curl -s -u $JIRA_USERNAME:$JIRA_API_TOKEN \
-            -X GET \
+          response=$(curl -D- \
+            -u $JIRA_USERNAME:$JIRA_API_TOKEN \
+            -X POST \
             -H "Content-Type: application/json" \
-            "$JIRA_URL/rest/api/2/search?jql=$JQL_QUERY")
+            --data '{"jql":"project = ND","fields":["id","key"]}' \
+            "$JIRA_URL/rest/api/2/search")
           
-          echo "RESPONSE=$response" >> $GITHUB_ENV
+          echo $response
           
           # Check if the response is valid JSON
           if echo "$response" | jq -e . >/dev/null 2>&1; then

--- a/.github/workflows/dependabot-pr-to-jira.yml
+++ b/.github/workflows/dependabot-pr-to-jira.yml
@@ -53,7 +53,7 @@ jobs:
           response=$(curl -s -u $JIRA_USERNAME:$JIRA_API_TOKEN \
             -X GET \
             -H "Content-Type: application/json" \
-            "$JIRA_URL/rest/api/2/search?jql=$JQL_QUERY")
+            "$JIRA_URL/rest/api/2/search?jql=project=ND%20AND%20labels%3D%27Dependabot%27")
           echo "$response" > jira_search_response.json
           issue_count=$(echo "$response" | jq '.issues | length')
           echo "Number of issues found: $issue_count"

--- a/.github/workflows/dependabot-pr-to-jira.yml
+++ b/.github/workflows/dependabot-pr-to-jira.yml
@@ -16,7 +16,7 @@ jobs:
     runs-on: ubuntu-latest
     name: Create or Update Jira Ticket
     steps:
-      -
+
       - name: List open Dependabot PRs on main branch
         id: list-prs
         env:

--- a/.github/workflows/dependabot-pr-to-jira.yml
+++ b/.github/workflows/dependabot-pr-to-jira.yml
@@ -59,7 +59,7 @@ jobs:
           response=$(curl -s -u $JIRA_USERNAME:$JIRA_API_TOKEN \
             -X GET \
             -H "Content-Type: application/json" \
-            "$JIRA_URL/rest/api/2/search?jql=project=ND%20AND%20labels%3D%27Dependabot%27%20AND%20status%3D%27Backlog%27)
+            "$JIRA_URL/rest/api/2/search?jql=project=ND%20AND%20labels%3D%27Dependabot%27%20AND%20status%3D%27Backlog%27")
           
           echo "$response" > jira_search_response.json
           

--- a/.github/workflows/dependabot-pr-to-jira.yml
+++ b/.github/workflows/dependabot-pr-to-jira.yml
@@ -56,10 +56,7 @@ jobs:
           response=$(curl -s -u $JIRA_USERNAME:$JIRA_API_TOKEN \
             -X GET \
             -H "Content-Type: application/json" \
-            "$JIRA_URL/rest/api/2/search?jql=project=ND AND labels='JDTEST'")
-          
-          # Write the response to an environment variable
-          echo "JIRA_RESPONSE=$response" >> $GITHUB_ENV
+            "$JIRA_URL/rest/api/2/search?jql=project=ND%20AND%20labels%3D%27JDTEST%27")
           
           # Check if the response is valid JSON
           if echo "$response" | jq -e . >/dev/null 2>&1; then

--- a/.github/workflows/dependabot-pr-to-jira.yml
+++ b/.github/workflows/dependabot-pr-to-jira.yml
@@ -56,7 +56,7 @@ jobs:
           response=$(curl -s -u $JIRA_USERNAME:$JIRA_API_TOKEN \
             -X GET \
             -H "Content-Type: application/json" \
-            "$JIRA_URL/rest/api/2/search?jql=project=ND AND labels=JDTEST")
+            "$JIRA_URL/rest/api/2/search?jql=project=ND AND labels='JDTEST'")
           
           # Write the response to an environment variable
           echo "JIRA_RESPONSE=$response" >> $GITHUB_ENV

--- a/.github/workflows/dependabot-pr-to-jira.yml
+++ b/.github/workflows/dependabot-pr-to-jira.yml
@@ -31,7 +31,7 @@ jobs:
       - name: Format PRs for Jira ticket Description
         id: format-prs
         run: |
-          PR_DESCRIPTION=$(jq -r '.[] | "- PR Number: \(.number)  Title: \(.title)  Branch: \(.headRefName)  URL: https://github.com/${{ github.repository }}/pull/\(.number)\n"' pr_list.json | sed ':a;N;$!ba;s/\n/\\n/g')
+          PR_DESCRIPTION=$(jq -r '.[] | "- PR Number: \(.number)  \nTitle: \(.title)  \nBranch: \(.headRefName)  \nURL: https://github.com/${{ github.repository }}/pull/\(.number)\n"' pr_list.json | sed ':a;N;$!ba;s/\n/\\n/g')
           echo "PR_DESCRIPTION=$PR_DESCRIPTION" >> $GITHUB_ENV
 
       - name: Find Jira tickets in project ND labeled Dependabot

--- a/.github/workflows/dependabot-pr-to-jira.yml
+++ b/.github/workflows/dependabot-pr-to-jira.yml
@@ -28,10 +28,10 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
-        # Get a list of open PRs created by 'app/dependabot' or 'dependabot[bot]' and save them to a JSON file
+          # Get a list of open PRs created by 'app/dependabot' or 'dependabot[bot]' and save them to a JSON file
           gh pr list --repo ${{ github.repository }} --base main --json number,title,headRefName --search "author:app/dependabot author:dependabot[bot] status:success review:none" > pr_list.json
   
-        # Check if the output is valid JSON
+          # Check if the output is valid JSON
           if ! jq -e . pr_list.json > /dev/null 2>&1; then
             echo "Invalid JSON output from gh pr list"
             cat pr_list.json

--- a/.github/workflows/dependabot-pr-to-jira.yml
+++ b/.github/workflows/dependabot-pr-to-jira.yml
@@ -53,19 +53,19 @@ jobs:
           JQL_QUERY='project="ND" AND labels="jira_dependabot"'
           
           # Make API request to Jira to search for issues with the given label in the 'ND' project
-          response=$(curl -D- \
-            -u $JIRA_USERNAME:$JIRA_API_TOKEN \
+          response=$(curl -s -u $JIRA_USERNAME:$JIRA_API_TOKEN \
             -X POST \
             -H "Content-Type: application/json" \
-            --data '{"jql":"project = ND","fields":["id","key"]}' \
+            --data "{\"jql\":\"$JQL_QUERY\",\"fields\":[\"id\",\"key\"]}" \
             "$JIRA_URL/rest/api/2/search")
           
-          echo $response
+          # Write the response to an environment variable
+          echo "JIRA_RESPONSE=$response" >> $GITHUB_ENV
           
           # Check if the response is valid JSON
           if echo "$response" | jq -e . >/dev/null 2>&1; then
             # Extract the first issue key from the response
-            issue_id=$(echo $response | jq -r '.issues[0].key')
+            issue_id=$(echo "$response" | jq -r '.issues[0].key')
           
             if [ -z "$issue_id" ]; then
               echo "No issues found with the 'jira_dependabot' label in project 'ND'."
@@ -77,9 +77,9 @@ jobs:
             echo "Invalid JSON response"
             exit 1
           fi
-    
-          - name: Log created or updated issue
-            run: |
+
+      - name: Log created or updated issue
+        run: |
               if [ -n "${{ env.ISSUE_ID }}" ]; then
                 echo "Issue ${{ env.ISSUE_ID }} was created or updated"
               else

--- a/.github/workflows/dependabot-pr-to-jira.yml
+++ b/.github/workflows/dependabot-pr-to-jira.yml
@@ -71,7 +71,7 @@ jobs:
               update_response=$(curl -s -u $JIRA_USERNAME:$JIRA_API_TOKEN \
                  -X PUT \
                  -H "Content-Type: application/json" \
-                 --data "{\"fields\":{\"description\":\"Updated\n $PR_DESCRIPTION\"}}" \
+                 --data "{\"fields\":{\"description\":\"Updated on $CURRENT_DATE \n $PR_DESCRIPTION\"}}" \
                  "$JIRA_URL/rest/api/2/issue/$issue_id")
               echo "Updated issue $issue_id"
               echo "ISSUE_ID=$issue_id" >> $GITHUB_ENV

--- a/.github/workflows/dependabot-pr-to-jira.yml
+++ b/.github/workflows/dependabot-pr-to-jira.yml
@@ -44,7 +44,7 @@ jobs:
           CURRENT_DATE=$(date '+%Y-%m-%d %H:%M:%S')
           echo "Searching for issues with the 'Dependabot' label in project 'ND'..."
           
-        # Define JQL query to find issues with the 'dependabot' label in the 'ND' project
+          # Define JQL query to find issues with the 'dependabot' label in the 'ND' project
           JQL_QUERY='project = ND AND labels in (Dependabot)'
           
           # Make API request to Jira to search for issues with the given label in the 'ND' project

--- a/.github/workflows/dependabot-pr-to-jira.yml
+++ b/.github/workflows/dependabot-pr-to-jira.yml
@@ -56,7 +56,7 @@ jobs:
           response=$(curl -s -u $JIRA_USERNAME:$JIRA_API_TOKEN \
             -X GET \
             -H "Content-Type: application/json" \
-            "$JIRA_URL/rest/api/2/search?jql=ND%20AND%20labels%3D%27JDTEST%27&fields=id,key")
+            "$JIRA_URL/rest/api/2/search?jql=project=ND%20AND%20labels%3D%27JDTEST%27&fields=id,key")
           
           # Write the response to an environment variable
           echo "JIRA_RESPONSE=$response" >> $GITHUB_ENV

--- a/.github/workflows/dependabot-pr-to-jira.yml
+++ b/.github/workflows/dependabot-pr-to-jira.yml
@@ -50,7 +50,7 @@ jobs:
           echo "Searching for issues with the 'jira_dependabot' label in project 'ND'..."
           
           # Define JQL query to find issues with the 'dependabot' label in the 'ND' project
-          JQL_QUERY='project = ND AND labels = jira_dependabot'
+          JQL_QUERY='labels = jira_dependabot'
           
           # Make API request to Jira to search for issues with the given label in the 'ND' project
           response=$(curl -s -u $JIRA_USERNAME:$JIRA_API_TOKEN \

--- a/.github/workflows/dependabot-pr-to-jira.yml
+++ b/.github/workflows/dependabot-pr-to-jira.yml
@@ -53,35 +53,34 @@ jobs:
             "$JIRA_URL/rest/api/2/search?jql=project=ND%20AND%20labels%3D%27JDTEST%27")
           
           # Check if the response is valid JSON
-               if echo "$response" | jq -e . >/dev/null 2>&1; then
-          
-          # Extract the first issue key from the response
-               issue_id=$(echo "$response" | jq -r '.issues[0].key')
+          if echo "$response" | jq -e . >/dev/null 2>&1; then
+            # Extract the first issue key from the response
+            issue_id=$(echo "$response" | jq -r '.issues[0].key')
                
-               if [ -z "$issue_id" ]; then
-               echo "No issues found with the 'JDTEST' label in project 'ND'. Creating a new issue..."
-               create_response=$(curl -s -u $JIRA_USERNAME:$JIRA_API_TOKEN \
-               -X POST \
-               -H "Content-Type: application/json" \
-               --data "{\"fields\":{\"project\":{\"key\":\"ND\"},\"summary\":\"Dependabot PRs\",\"description\":\"$PR_DESCRIPTION\",\"labels\":[\"jira_dependabot\"]}}" \
-               "$JIRA_URL/rest/api/2/issue")
-               new_issue_id=$(echo "$create_response" | jq -r '.key')
-               echo "Created new issue $new_issue_id"
-               echo "ISSUE_ID=$new_issue_id" >> $GITHUB_ENV
-               else
-               echo "Found issue $issue_id. Updating the description..."
-               update_response=$(curl -s -u $JIRA_USERNAME:$JIRA_API_TOKEN \
-               -X PUT \
-               -H "Content-Type: application/json" \
-               --data "{\"fields\":{\"description\":\"$PR_DESCRIPTION\"}}" \
-               "$JIRA_URL/rest/api/2/issue/$issue_id")
-               echo "Updated issue $issue_id"
-               echo "ISSUE_ID=$issue_id" >> $GITHUB_ENV
-               fi
-               else
-               echo "Invalid JSON response"
-               exit 1
-               fi
+            if [ -z "$issue_id" ]; then
+              echo "No issues found with the 'JDTEST' label in project 'ND'. Creating a new issue..."
+              create_response=$(curl -s -u $JIRA_USERNAME:$JIRA_API_TOKEN \
+                 -X POST \
+                 -H "Content-Type: application/json" \
+                 --data "{\"fields\":{\"project\":{\"key\":\"ND\"},\"summary\":\"Dependabot PRs\",\"description\":\"$PR_DESCRIPTION\",\"labels\":[\"jira_dependabot\"]}}" \
+                 "$JIRA_URL/rest/api/2/issue")
+              new_issue_id=$(echo "$create_response" | jq -r '.key')
+              echo "Created new issue $new_issue_id"
+              echo "ISSUE_ID=$new_issue_id" >> $GITHUB_ENV
+            else
+              echo "Found issue $issue_id. Updating the description..."
+              update_response=$(curl -s -u $JIRA_USERNAME:$JIRA_API_TOKEN \
+                 -X PUT \
+                 -H "Content-Type: application/json" \
+                 --data "{\"fields\":{\"description\":\"$PR_DESCRIPTION\"}}" \
+                 "$JIRA_URL/rest/api/2/issue/$issue_id")
+              echo "Updated issue $issue_id"
+              echo "ISSUE_ID=$issue_id" >> $GITHUB_ENV
+            fi
+          else
+            echo "Invalid JSON response"
+            exit 1
+          fi
 
 
       - name: Log created or updated issue

--- a/.github/workflows/dependabot-pr-to-jira.yml
+++ b/.github/workflows/dependabot-pr-to-jira.yml
@@ -31,7 +31,7 @@ jobs:
       - name: Format PRs for Jira ticket Description
         id: format-prs
         run: |
-          PR_DESCRIPTION=$(jq -r '.[] | "- PR Number: \(.number)  \nTitle: \(.title)  \nBranch: \(.headRefName) \nAuthor: (.author) \nURL: https://github.com/${{ github.repository }}/pull/\(.number)\n"' pr_list.json | sed ':a;N;$!ba;s/\n/\\n/g')
+          PR_DESCRIPTION=$(jq -r '.[] | "- PR Number: \(.number)  \nTitle: \(.title)  \nBranch: \(.headRefName) \nAuthor: (.author.login) \nURL: https://github.com/${{ github.repository }}/pull/\(.number)\n"' pr_list.json | sed ':a;N;$!ba;s/\n/\\n/g')
           echo "PR_DESCRIPTION=$PR_DESCRIPTION" >> $GITHUB_ENV
 
       - name: Find Jira tickets in project ND labeled Dependabot

--- a/.github/workflows/dependabot-pr-to-jira.yml
+++ b/.github/workflows/dependabot-pr-to-jira.yml
@@ -67,7 +67,7 @@ jobs:
               create_response=$(curl -s -u $JIRA_USERNAME:$JIRA_API_TOKEN \
                  -X POST \
                  -H "Content-Type: application/json" \
-                 --data "{\"fields\":{\"project\":{\"key\":\"ND\"},\"summary\":\"Dependabot PRs\",\"description\":\"$PR_DESCRIPTION\",\issuetype\":{\"name"}:\"Story"\,\"labels\":[\"Dependabot\"]}}" \
+                 --data "{\"fields\":{\"project\":{\"key\":\"ND\"},\"summary\":\"Dependabot PRs\",\"description\":\"$PR_DESCRIPTION\",\"issuetype\":{\"name\"}:\"Story\",\"labels\":[\"Dependabot\"]}}" \
                  "$JIRA_URL/rest/api/2/issue")
             
               echo "$create_response" 

--- a/.github/workflows/dependabot-pr-to-jira.yml
+++ b/.github/workflows/dependabot-pr-to-jira.yml
@@ -21,7 +21,7 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
-          gh pr list --repo ${{ github.repository }} --base main --json number,title,headRefName,author --author dependabot > pr_list.json
+          gh pr list --repo ${{ github.repository }} --base main --json number,title,headRefName,author > pr_list.json
           if ! jq -e . pr_list.json > /dev/null 2>&1; then
             echo "Invalid JSON output from gh pr list"
             cat pr_list.json
@@ -31,7 +31,7 @@ jobs:
       - name: Format PRs for Jira ticket Description
         id: format-prs
         run: |
-          PR_DESCRIPTION=$(jq -r '.[] | "- PR Number: \(.number)  \nTitle: \(.title)  \nBranch: \(.headRefName)  \nURL: https://github.com/${{ github.repository }}/pull/\(.number)\n"' pr_list.json | sed ':a;N;$!ba;s/\n/\\n/g')
+          PR_DESCRIPTION=$(jq -r '.[] | "- PR Number: \(.number)  \nTitle: \(.title)  \nBranch: \(.headRefName) \nAuthor: (.author) \nURL: https://github.com/${{ github.repository }}/pull/\(.number)\n"' pr_list.json | sed ':a;N;$!ba;s/\n/\\n/g')
           echo "PR_DESCRIPTION=$PR_DESCRIPTION" >> $GITHUB_ENV
 
       - name: Find Jira tickets in project ND labeled Dependabot

--- a/.github/workflows/dependabot-pr-to-jira.yml
+++ b/.github/workflows/dependabot-pr-to-jira.yml
@@ -2,13 +2,13 @@ on:
   workflow_call:
     secrets:
       TECH_SERVICES_JIRA_URL:
-        description: 'jira URL passed from the caller workflow'
+        description: 'Jira URL passed from the caller workflow'
         required: true
       TECH_SERVICES_JIRA_EMAIL:
-        description: 'email address passed from the caller workflow'
+        description: 'Email address passed from the caller workflow'
         required: true
       TECH_SERVICES_JIRA_TOKEN:
-        description: 'A token passed from the caller workflow'
+        description: 'API token passed from the caller workflow'
         required: true
 
 jobs:
@@ -16,24 +16,31 @@ jobs:
     runs-on: ubuntu-latest
     name: Create or Update Jira Ticket
     steps:
+      # Step 1: List open Dependabot PRs on the main branch
       - name: List open Dependabot PRs on main branch
         id: list-prs
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
+          # Get a list of open PRs with the 'dependabot' label, and save them to a JSON file
           gh pr list --repo ${{ github.repository }} --base main --json number,title,headRefName -A app/dependabot --search "status:success review:none" > pr_list.json
+          
+          # Check if the output is valid JSON
           if ! jq -e . pr_list.json > /dev/null 2>&1; then
             echo "Invalid JSON output from gh pr list"
             cat pr_list.json
             exit 1
           fi
 
+      # Step 2: Format the PRs for Jira ticket description
       - name: Format PRs for Jira ticket Description
         id: format-prs
         run: |
+          # Format PR details into a description suitable for a Jira issue
           PR_DESCRIPTION=$(jq -r '.[] | "- PR Number: \(.number)  \nTitle: \(.title)  \nBranch: \(.headRefName) \nURL: https://github.com/${{ github.repository }}/pull/\(.number)\n"' pr_list.json | sed ':a;N;$!ba;s/\n/\\n/g')
           echo "PR_DESCRIPTION=$PR_DESCRIPTION" >> $GITHUB_ENV
 
+      # Step 3: Find Jira tickets in project ND labeled 'Dependabot'
       - name: Find Jira tickets in project ND labeled Dependabot
         id: find-jira-ticket
         env:
@@ -44,7 +51,7 @@ jobs:
           CURRENT_DATE=$(date '+%Y-%m-%d %H:%M:%S')
           echo "Searching for issues with the 'Dependabot' label in project 'ND'..."
           
-          # Define JQL query to find issues with the 'dependabot' label in the 'ND' project
+          # Define JQL query to find issues with the 'Dependabot' label in the 'ND' project
           JQL_QUERY='project = ND AND labels in (Dependabot)'
           
           # Make API request to Jira to search for issues with the given label in the 'ND' project
@@ -53,30 +60,38 @@ jobs:
             -H "Content-Type: application/json" \
             "$JIRA_URL/rest/api/2/search?jql=project=ND%20AND%20labels%3D%27Dependabot%27")
           
+          # Count the number of issues returned by Jira
           issue_count=$(echo "$response" | jq '.issues | length')
           echo "Number of issues found: $issue_count"
           
           # Check if the response is valid JSON
-
           if echo "$response" | jq -e . >/dev/null 2>&1; then
-            # Extract the first issue key from the response
-             issue_id=$(echo "$response" | jq -r '.issues[0].key // "null"')
-            
+            # Extract the issue key (ID) of the first issue from the response
+            issue_id=$(echo "$response" | jq -r '.issues[0].key // "null"')
+          
+            # If no issues are found, create a new issue
             if [ "$issue_count" -eq 0 ]; then
               echo "No issues found with the 'Dependabot' label in project 'ND'. Creating a new issue..."
+          
+              # Create a new Jira issue with the formatted PR description
               create_response=$(curl -s -u $JIRA_USERNAME:$JIRA_API_TOKEN \
                  -X POST \
                  -H "Content-Type: application/json" \
                  --data "{\"fields\":{\"project\":{\"key\":\"ND\"},\"summary\":\"Dependabot PRs\",\"description\":\"$PR_DESCRIPTION\",\"issuetype\":{\"name\":\"Story\"},\"labels\":[\"Dependabot\"]}}" \
                  "$JIRA_URL/rest/api/2/issue")
-            
+          
+              # Output the full response for logging
               echo "$create_response" 
-              
+          
+              # Extract the issue ID of the newly created issue
               new_issue_id=$(echo "$create_response" | jq -r '.key')
               echo "Created new issue $new_issue_id"
               echo "ISSUE_ID=$new_issue_id" >> $GITHUB_ENV
             else
+              # If an issue exists, update the description
               echo "Found issue $issue_id. Updating the description..."
+          
+              # Update the existing issue's description with new PR details
               update_response=$(curl -s -u $JIRA_USERNAME:$JIRA_API_TOKEN \
                  -X PUT \
                  -H "Content-Type: application/json" \
@@ -86,13 +101,16 @@ jobs:
               echo "ISSUE_ID=$issue_id" >> $GITHUB_ENV
             fi
           else
+            # If the response is invalid JSON, exit with an error
             echo "Invalid JSON response"
             exit 1
           fi
 
+      # Step 4: Log the issue created or updated
       - name: Log created or updated issue
         id: log-issue-update
         run: |
+          # Check if the ISSUE_ID environment variable is set
           if [ -n "${{ env.ISSUE_ID }}" ]; then
             echo "Issue ${{ env.ISSUE_ID }} was created or updated"
           else
@@ -100,13 +118,17 @@ jobs:
             exit 1
           fi
 
+      # Step 5: Comment on all related PRs on GitHub
       - name: Comment on GitHub
         id: comment-prs
         uses: actions/github-script@v7
         with:
           script: |
+            # Read the list of PRs from the generated JSON file
             const fs = require('fs');
             const prs = JSON.parse(fs.readFileSync('pr_list.json', 'utf8'));
+            
+            # Loop through all PRs and add a comment indicating the Jira issue update
             prs.forEach(pr => {
               github.rest.issues.createComment({
                 issue_number: pr.number,
@@ -116,6 +138,7 @@ jobs:
               });
             });
 
+      # Step 6: Find transition ID for 'Backlog' in Jira
       - name: Find transition ID for Backlog
         id: transition-issue
         env:
@@ -123,16 +146,20 @@ jobs:
           JIRA_API_TOKEN: ${{ secrets.TECH_SERVICES_JIRA_TOKEN }}
           JIRA_USERNAME: ${{ secrets.TECH_SERVICES_JIRA_EMAIL }}
         run: |
+          # Get the available transitions for the Jira issue
           transition_response=$(curl -s -u $JIRA_USERNAME:$JIRA_API_TOKEN \
             -X GET \
             -H "Content-Type: application/json" \
             "$JIRA_URL/rest/api/2/issue/${{ env.ISSUE_ID }}/transitions")
           
+          # Find the transition ID for 'Backlog'
           transition_id=$(echo "$transition_response" | jq -r '.transitions[] | select(.name=="Backlog") | .id')
           
+          # If the transition ID is not found, exit with an error
           if [ -z "$transition_id" ]; then
             echo "Failed to find transition ID for 'Backlog'"
             exit 1
           fi
           
+          # Output the transition ID for logging
           echo "TRANSITION_ID=$transition_id" >> $GITHUB_ENV

--- a/.github/workflows/dependabot-pr-to-jira.yml
+++ b/.github/workflows/dependabot-pr-to-jira.yml
@@ -55,7 +55,7 @@ jobs:
           JIRA_USERNAME: ${{ secrets.TECH_SERVICES_JIRA_EMAIL }}
         run: |
           echo "Searching for issues with the 'Dependabot' label in project 'ND'..."
-          JQL_QUERY='project = ND AND labels in (Dependabot)'
+          JQL_QUERY='project = ND AND labels in (Dependabot) AND state in (Backlog)'
           response=$(curl -s -u $JIRA_USERNAME:$JIRA_API_TOKEN \
             -X GET \
             -H "Content-Type: application/json" \

--- a/.github/workflows/dependabot-pr-to-jira.yml
+++ b/.github/workflows/dependabot-pr-to-jira.yml
@@ -106,9 +106,22 @@ jobs:
               });
             });
 
-      - name: Transition issue
-        uses: atlassian/gajira-transition@master
-        with:
-          issue: ${{ env.ISSUE_ID}}
-          transition: "Backlog"
-        continue-on-error: true
+      - name: Find transition ID for Backlog
+        env:
+          JIRA_URL: ${{ secrets.TECH_SERVICES_JIRA_URL }}
+          JIRA_API_TOKEN: ${{ secrets.TECH_SERVICES_JIRA_TOKEN }}
+          JIRA_USERNAME: ${{ secrets.TECH_SERVICES_JIRA_EMAIL }}
+        run: |
+          transition_response=$(curl -s -u $JIRA_USERNAME:$JIRA_API_TOKEN \
+            -X GET \
+            -H "Content-Type: application/json" \
+            "$JIRA_URL/rest/api/2/issue/${{ env.ISSUE_ID }}/transitions")
+          
+          transition_id=$(echo "$transition_response" | jq -r '.transitions[] | select(.name=="Backlog") | .id')
+          
+          if [ -z "$transition_id" ]; then
+            echo "Failed to find transition ID for 'Backlog'"
+            exit 1
+          fi
+          
+          echo "TRANSITION_ID=$transition_id" >> $GITHUB_ENV

--- a/.github/workflows/dependabot-pr-to-jira.yml
+++ b/.github/workflows/dependabot-pr-to-jira.yml
@@ -16,13 +16,7 @@ jobs:
     runs-on: ubuntu-latest
     name: Create or Update Jira Ticket
     steps:
-      - name: Login
-        uses: atlassian/gajira-login@master
-        env:
-          JIRA_BASE_URL: ${{ secrets.TECH_SERVICES_JIRA_URL }}
-          JIRA_USER_EMAIL: ${{ secrets.TECH_SERVICES_JIRA_EMAIL }}
-          JIRA_API_TOKEN: ${{ secrets.TECH_SERVICES_JIRA_TOKEN }}
-
+      -
       - name: List open Dependabot PRs on main branch
         id: list-prs
         env:
@@ -59,20 +53,36 @@ jobs:
             "$JIRA_URL/rest/api/2/search?jql=project=ND%20AND%20labels%3D%27JDTEST%27")
           
           # Check if the response is valid JSON
-          if echo "$response" | jq -e . >/dev/null 2>&1; then
-            # Extract the first issue key from the response
-            issue_id=$(echo "$response" | jq -r '.issues[0].key')
+               if echo "$response" | jq -e . >/dev/null 2>&1; then
           
-            if [ -z "$issue_id" ]; then
-              echo "No issues found with the 'jira_dependabot' label in project 'ND'."
-            else
-              echo "Found issue $issue_id"
-              echo "ISSUE_ID=$issue_id" >> $GITHUB_ENV
-            fi
-          else
-            echo "Invalid JSON response"
-            exit 1
-          fi
+          # Extract the first issue key from the response
+               issue_id=$(echo "$response" | jq -r '.issues[0].key')
+               
+               if [ -z "$issue_id" ]; then
+               echo "No issues found with the 'JDTEST' label in project 'ND'. Creating a new issue..."
+               create_response=$(curl -s -u $JIRA_USERNAME:$JIRA_API_TOKEN \
+               -X POST \
+               -H "Content-Type: application/json" \
+               --data "{\"fields\":{\"project\":{\"key\":\"ND\"},\"summary\":\"Dependabot PRs\",\"description\":\"$PR_DESCRIPTION\",\"labels\":[\"jira_dependabot\"]}}" \
+               "$JIRA_URL/rest/api/2/issue")
+               new_issue_id=$(echo "$create_response" | jq -r '.key')
+               echo "Created new issue $new_issue_id"
+               echo "ISSUE_ID=$new_issue_id" >> $GITHUB_ENV
+               else
+               echo "Found issue $issue_id. Updating the description..."
+               update_response=$(curl -s -u $JIRA_USERNAME:$JIRA_API_TOKEN \
+               -X PUT \
+               -H "Content-Type: application/json" \
+               --data "{\"fields\":{\"description\":\"$PR_DESCRIPTION\"}}" \
+               "$JIRA_URL/rest/api/2/issue/$issue_id")
+               echo "Updated issue $issue_id"
+               echo "ISSUE_ID=$issue_id" >> $GITHUB_ENV
+               fi
+               else
+               echo "Invalid JSON response"
+               exit 1
+               fi
+
 
       - name: Log created or updated issue
         run: |

--- a/.github/workflows/dependabot-pr-to-jira.yml
+++ b/.github/workflows/dependabot-pr-to-jira.yml
@@ -59,7 +59,7 @@ jobs:
           response=$(curl -s -u $JIRA_USERNAME:$JIRA_API_TOKEN \
             -X GET \
             -H "Content-Type: application/json" \
-            "$JIRA_URL/rest/api/2/search?jql=project=ND%20AND%20labels%3D%27Dependabot%27")
+            "$JIRA_URL/rest/api/2/search?jql=project=ND%20AND%20labels%3D%27Dependabot%27%20AND%20status%3D%27Backlog%27)
           
           echo "$response" > jira_search_response.json
           

--- a/.github/workflows/dependabot-pr-to-jira.yml
+++ b/.github/workflows/dependabot-pr-to-jira.yml
@@ -41,7 +41,7 @@ jobs:
           JIRA_API_TOKEN: ${{ secrets.TECH_SERVICES_JIRA_TOKEN }}
           JIRA_USERNAME: ${{ secrets.TECH_SERVICES_JIRA_EMAIL }}
         run: |
-          echo "Searching for issues with the 'jira_dependabot' label in project 'ND'..."
+          echo "Searching for issues with the 'JDTEST' label in project 'ND'..."
           
           # Define JQL query to find issues with the 'dependabot' label in the 'ND' project
           JQL_QUERY='project = ND AND labels in (JDTEST)'

--- a/.github/workflows/dependabot-pr-to-jira.yml
+++ b/.github/workflows/dependabot-pr-to-jira.yml
@@ -78,7 +78,7 @@ jobs:
           create_response=$(curl -s -u $JIRA_USERNAME:$JIRA_API_TOKEN \
              -X POST \
              -H "Content-Type: application/json" \
-             --data "{\"fields\":{\"project\":{\"key\":\"ND\"},\"summary\":\"Dependabot PRs\",\"description\":\"$PR_DESCRIPTION\",\"issuetype\":{\"name\":\"Story\"},\"labels\":[\"Dependabot\"]}}" \
+             --data "{\"fields\":{\"project\":{\"key\":\"ND\"},\"summary\":\"Dependabot PRs for ${{ github.repository }}\",\"description\":\"$PR_DESCRIPTION\",\"issuetype\":{\"name\":\"Story\"},\"labels\":[\"Dependabot\"]}}" \
              "$JIRA_URL/rest/api/2/issue")
           echo "$create_response" 
           new_issue_id=$(echo "$create_response" | jq -r '.key')

--- a/.github/workflows/dependabot-pr-to-jira.yml
+++ b/.github/workflows/dependabot-pr-to-jira.yml
@@ -78,7 +78,7 @@ jobs:
           create_response=$(curl -s -u $JIRA_USERNAME:$JIRA_API_TOKEN \
              -X POST \
              -H "Content-Type: application/json" \
-             --data "{\"fields\":{\"project\":{\"key\":\"ND\"},\"summary\":\"Dependabot PRs for ${{ github.repository }}\",\"description\":\"$PR_DESCRIPTION\",\"issuetype\":{\"name\":\"Story\"},\"labels\":[\"Dependabot\"]}}" \
+             --data "{\"fields\":{\"project\":{\"key\":\"ND\"},\"summary\":\"Dependabot PRs for ${{ github.repository }}\",\"description\":\"Repository : ${{ github.repository }} \n $PR_DESCRIPTION\",\"issuetype\":{\"name\":\"Story\"},\"labels\":[\"Dependabot\",\"${{ github.repository }}\"]}}" \
              "$JIRA_URL/rest/api/2/issue")
           echo "$create_response" 
           new_issue_id=$(echo "$create_response" | jq -r '.key')

--- a/.github/workflows/dependabot-pr-to-jira.yml
+++ b/.github/workflows/dependabot-pr-to-jira.yml
@@ -67,7 +67,7 @@ jobs:
               create_response=$(curl -s -u $JIRA_USERNAME:$JIRA_API_TOKEN \
                  -X POST \
                  -H "Content-Type: application/json" \
-                 --data "{\"fields\":{\"project\":{\"key\":\"ND\"},\"summary\":\"Dependabot PRs\",\"description\":\"$PR_DESCRIPTION\",\"labels\":[\"Dependabot\"]}}" \
+                 --data "{\"fields\":{\"project\":{\"key\":\"ND\"},\"summary\":\"Dependabot PRs\",\"description\":\"$PR_DESCRIPTION\",\issuetype\":{\"name"}:\"Story"\,\"labels\":[\"Dependabot\"]}}" \
                  "$JIRA_URL/rest/api/2/issue")
             
               echo "$create_response" 

--- a/.github/workflows/dependabot-pr-to-jira.yml
+++ b/.github/workflows/dependabot-pr-to-jira.yml
@@ -56,7 +56,7 @@ jobs:
           response=$(curl -s -u $JIRA_USERNAME:$JIRA_API_TOKEN \
             -X GET \
             -H "Content-Type: application/json" \
-            "$JIRA_URL/rest/api/2/search?jql=$JQL_QUERY")
+            "$JIRA_URL/rest/api/2/search?jql=ND%20AND%20labels%3D%27JDTEST%27&fields=id,key")
           
           # Write the response to an environment variable
           echo "JIRA_RESPONSE=$response" >> $GITHUB_ENV

--- a/.github/workflows/dependabot-pr-to-jira.yml
+++ b/.github/workflows/dependabot-pr-to-jira.yml
@@ -56,7 +56,7 @@ jobs:
           response=$(curl -s -u $JIRA_USERNAME:$JIRA_API_TOKEN \
             -X GET \
             -H "Content-Type: application/json" \
-            "$JIRA_URL/rest/api/2/search?jql=project=ND%20AND%20labels%3D%27JDTEST%27&fields=id,key")
+            "$JIRA_URL/rest/api/2/search?jql=project=ND AND labels=JDTEST")
           
           # Write the response to an environment variable
           echo "JIRA_RESPONSE=$response" >> $GITHUB_ENV

--- a/.github/workflows/dependabot-pr-to-jira.yml
+++ b/.github/workflows/dependabot-pr-to-jira.yml
@@ -35,6 +35,7 @@ jobs:
           echo "PR_DESCRIPTION=$PR_DESCRIPTION" >> $GITHUB_ENV
 
       - name: Find Jira tickets in project ND labeled Dependabot
+        id: find-jira-ticket
         env:
           JIRA_URL: ${{ secrets.TECH_SERVICES_JIRA_URL }}
           JIRA_API_TOKEN: ${{ secrets.TECH_SERVICES_JIRA_TOKEN }}
@@ -43,7 +44,7 @@ jobs:
           CURRENT_DATE=$(date '+%Y-%m-%d %H:%M:%S')
           echo "Searching for issues with the 'Dependabot' label in project 'ND'..."
           
-          # Define JQL query to find issues with the 'dependabot' label in the 'ND' project
+        # Define JQL query to find issues with the 'dependabot' label in the 'ND' project
           JQL_QUERY='project = ND AND labels in (Dependabot)'
           
           # Make API request to Jira to search for issues with the given label in the 'ND' project
@@ -53,9 +54,10 @@ jobs:
             "$JIRA_URL/rest/api/2/search?jql=project=ND%20AND%20labels%3D%27Dependabot%27")
           
           # Check if the response is valid JSON
+
           if echo "$response" | jq -e . >/dev/null 2>&1; then
             # Extract the first issue key from the response
-            issue_id=$(echo "$response" | jq -r '.issues[0].key')
+             issue_id=$(echo "$response" | jq -r '.issues[0].key // "null"')
             echo " issue_id from response $issue_id"
           
             if [ -z "$issue_id" ]; then
@@ -84,6 +86,7 @@ jobs:
           fi
 
       - name: Log created or updated issue
+        id: log-issue-update
         run: |
           if [ -n "${{ env.ISSUE_ID }}" ]; then
             echo "Issue ${{ env.ISSUE_ID }} was created or updated"
@@ -93,6 +96,7 @@ jobs:
           fi
 
       - name: Comment on GitHub
+        id: comment-prs
         uses: actions/github-script@v7
         with:
           script: |
@@ -108,6 +112,7 @@ jobs:
             });
 
       - name: Find transition ID for Backlog
+        id: transition-issue
         env:
           JIRA_URL: ${{ secrets.TECH_SERVICES_JIRA_URL }}
           JIRA_API_TOKEN: ${{ secrets.TECH_SERVICES_JIRA_TOKEN }}

--- a/.github/workflows/dependabot-pr-to-jira.yml
+++ b/.github/workflows/dependabot-pr-to-jira.yml
@@ -21,7 +21,7 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
-          gh pr list --repo ${{ github.repository }} --base main --json number,title,headRefName,author > pr_list.json
+          gh pr list --repo ${{ github.repository }} --base main --json number,title,headRefName -A app/dependabot --search "status:success review:none" > pr_list.json
           if ! jq -e . pr_list.json > /dev/null 2>&1; then
             echo "Invalid JSON output from gh pr list"
             cat pr_list.json
@@ -31,7 +31,7 @@ jobs:
       - name: Format PRs for Jira ticket Description
         id: format-prs
         run: |
-          PR_DESCRIPTION=$(jq -r '.[] | "- PR Number: \(.number)  \nTitle: \(.title)  \nBranch: \(.headRefName) \nAuthor: (.author.login) \nURL: https://github.com/${{ github.repository }}/pull/\(.number)\n"' pr_list.json | sed ':a;N;$!ba;s/\n/\\n/g')
+          PR_DESCRIPTION=$(jq -r '.[] | "- PR Number: \(.number)  \nTitle: \(.title)  \nBranch: \(.headRefName) \nURL: https://github.com/${{ github.repository }}/pull/\(.number)\n"' pr_list.json | sed ':a;N;$!ba;s/\n/\\n/g')
           echo "PR_DESCRIPTION=$PR_DESCRIPTION" >> $GITHUB_ENV
 
       - name: Find Jira tickets in project ND labeled Dependabot

--- a/.github/workflows/dependabot-pr-to-jira.yml
+++ b/.github/workflows/dependabot-pr-to-jira.yml
@@ -61,7 +61,7 @@ jobs:
               create_response=$(curl -s -u $JIRA_USERNAME:$JIRA_API_TOKEN \
                  -X POST \
                  -H "Content-Type: application/json" \
-                 --data "{\"fields\":{\"project\":{\"key\":\"ND\"},\"summary\":\"Dependabot PRs\",\"description\":\"$PR_DESCRIPTION\",\"labels\":[\"jira_dependabot\"]}}" \
+                 --data "{\"fields\":{\"project\":{\"key\":\"ND\"},\"summary\":\"Dependabot PRs\",\"description\":\"Updated $PR_DESCRIPTION\",\"labels\":[\"JDTEST\"]}}" \
                  "$JIRA_URL/rest/api/2/issue")
               new_issue_id=$(echo "$create_response" | jq -r '.key')
               echo "Created new issue $new_issue_id"

--- a/.github/workflows/dependabot-pr-to-jira.yml
+++ b/.github/workflows/dependabot-pr-to-jira.yml
@@ -16,7 +16,6 @@ jobs:
     runs-on: ubuntu-latest
     name: Create or Update Jira Ticket
     steps:
-
       - name: List open Dependabot PRs on main branch
         id: list-prs
         env:
@@ -56,7 +55,7 @@ jobs:
           if echo "$response" | jq -e . >/dev/null 2>&1; then
             # Extract the first issue key from the response
             issue_id=$(echo "$response" | jq -r '.issues[0].key')
-               
+          
             if [ -z "$issue_id" ]; then
               echo "No issues found with the 'JDTEST' label in project 'ND'. Creating a new issue..."
               create_response=$(curl -s -u $JIRA_USERNAME:$JIRA_API_TOKEN \
@@ -82,15 +81,14 @@ jobs:
             exit 1
           fi
 
-
       - name: Log created or updated issue
         run: |
-              if [ -n "${{ env.ISSUE_ID }}" ]; then
-                echo "Issue ${{ env.ISSUE_ID }} was created or updated"
-              else
-                echo "Failed to create or update issue"
-                exit 1
-              fi
+          if [ -n "${{ env.ISSUE_ID }}" ]; then
+            echo "Issue ${{ env.ISSUE_ID }} was created or updated"
+          else
+            echo "Failed to create or update issue"
+            exit 1
+          fi
 
       - name: Comment on GitHub
         uses: actions/github-script@v7

--- a/.github/workflows/dependabot-pr-to-jira.yml
+++ b/.github/workflows/dependabot-pr-to-jira.yml
@@ -85,12 +85,15 @@ jobs:
           JIRA_USERNAME: ${{ secrets.TECH_SERVICES_JIRA_EMAIL }}
         run: |
           echo "No issues found with the 'Dependabot' label in project 'ND'. Creating a new issue..."
+          
           create_response=$(curl -s -u $JIRA_USERNAME:$JIRA_API_TOKEN \
              -X POST \
              -H "Content-Type: application/json" \
-             --data "{\"fields\":{\"project\":{\"key\":\"ND\"},\"summary\":\"Dependabot PRs for ${{ env.REPO_NAME }}\",\"description\":\"Repository : ${{ env.REPO_NAME}} \n $PR_DESCRIPTION\",\"issuetype\":{\"name\":\"Story\"},\"labels\":[\"Dependabot\",\"${{ env.REPO_NAME }}"\]}}" \
+             --data "{\"fields\":{\"project\":{\"key\":\"ND\"},\"summary\":\"Dependabot PRs for ${{ env.REPO_NAME }}\",\"description\":\"Repository : ${{ env.REPO_NAME }} \\n $PR_DESCRIPTION\",\"issuetype\":{\"name\":\"Story\"},\"labels\":[\"Dependabot\",\"${{ env.REPO_NAME }}\"]}}" \
              "$JIRA_URL/rest/api/2/issue")
-          echo "$create_response" 
+          
+          echo "$create_response"
+          
           new_issue_id=$(echo "$create_response" | jq -r '.key')
           echo "Created new issue $new_issue_id"
           echo "ISSUE_ID=$new_issue_id" >> $GITHUB_ENV

--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ This repository was created as a central location to hold, manage and maintain o
 - [Label Pull Request](#label-pull-request)
 - [Issue to Jira](#issue-to-jira)
 - [Issue to Project](#issue-to-project)
+- [Dependabot PR to Jira](#dependabot_pr_to_jira)
 
 ## Label Issues
 
@@ -74,3 +75,54 @@ Use this action to automatically add the current issue or pull request to a GitH
 Marketplace Link: https://github.com/marketplace/actions/add-to-github-projects
 
 Add the `issue-to-project.yml` to the repository (`./github/workflows/issue-to-project.yml`), this file call the `ministryofjustice/nvvs-devops-github-actions/.github/workflows/issue-to-project.yml@main` action when an issue is opened. This action automatically adds the issue the GitHub project specified in the `project-url`.
+
+## Dependabot PR to Jira
+
+dependabot-pr-to-jira.yml workflow automates the process of creating or updating Jira tickets for open Dependabot pull requests (PRs) within a GitHub repository. 
+The workflow is scheduled to run every Monday at 4 PM UTC, ensuring regular tracking of new Dependabot PRs. 
+It integrates GitHub with Jira to automatically create and update Jira issues with relevant PR details, improving visibility and streamlining dependency management.
+
+Add the `dependabot-pr-to-jira.yml` to the repository (`./github/workflows/dependabot-pr-to-jira.yml`), this file calls the `ministryofjustice/nvvs-devops-github-actions/.github/workflows/dependabot-pr-to-jira.yml`.
+
+### Workflow Steps:
+### Trigger:
+
+Scheduled Trigger: The workflow is set to run every Monday at 4 PM UTC (via cron) to capture any open Dependabot PRs and create/update Jira tickets for them.
+
+Input Secrets: The workflow requires three secrets to authenticate and interact with Jira:
+
+TECH_SERVICES_JIRA_URL: Jira instance URL.
+TECH_SERVICES_JIRA_EMAIL: Email address for Jira authentication.
+TECH_SERVICES_JIRA_TOKEN: API token for Jira authentication.
+
+### Job: check-open-prs:
+
+Runs on: ubuntu-latest (GitHub-hosted runner).
+
+Purpose: This job is responsible for checking open Dependabot PRs, either creating or updating a Jira ticket with relevant PR details.
+
+### Steps:
+
+Set Repository Name: Extracts and stores the repository name for later use (e.g., in PR comments or Jira issue links).
+
+List Open Dependabot PRs: Uses GitHub CLI (gh) to list open PRs created by Dependabot. These PRs are filtered by their status (status:success and review:none).
+
+Format PR Details: PR details (number, title, branch name, and PR URL) are formatted into a description suitable for Jira.
+
+Find Existing Jira Tickets: Queries Jira using a JQL query to find any existing issues with the Dependabot label in the ND project.
+
+Create Jira Ticket: If no matching ticket is found, a new Jira issue is created with the formatted PR details.
+
+Update Jira Ticket: If an existing issue is found, the ticket's description is updated with the latest PR details and timestamp.
+
+Log the Issue: Logs the newly created or updated Jira ticket's ID.
+
+Comment on PRs: Comments on all related PRs in the GitHub repository, providing visibility that a Jira issue has been created or updated.
+
+Find Transition ID for Backlog: Retrieves the transition ID for moving the issue to the "Backlog" state in Jira (if needed for future steps).
+
+### Workflow Integrations:
+
+GitHub CLI (gh): Interacts with GitHub to list open PRs and fetch necessary details.
+
+Jira API: Used to interact with Jira for searching issues, creating new ones, updating existing issues, and managing transitions like moving issues to the "Backlog" state.


### PR DESCRIPTION
The dependabot-pr-to-jira.yml workflow automates the process of tracking Dependabot PRs in Jira.
It ensures that each PR is either matched to an existing Jira ticket or creates a new issue, allowing team to better manage dependency updates.

The workflow is scheduled to run every Monday at 4 PM UTC.

ND-271