### PR TITLE
ND-919 Added yarn package to the dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -25,3 +25,7 @@ updates:
     directory: "/"
     schedule:
       interval: "daily"
+  - package-ecosystem: "yarn"
+    directory: "/"
+    schedule:
+      interval: "daily"


### PR DESCRIPTION
We need to configure Dependabot to monitor the govuk-frontend package using Yarn as the package ecosystem. This change is necessary because our project is built on the ruby:3.3.6-alpine3.19 Docker image, which includes Yarn by default but does not include npm out of the box. As a result, our project uses Yarn for managing frontend dependencies, including govuk-frontend.